### PR TITLE
Change Stripe charge amount from 1.5% to 1.4%.

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,7 +409,7 @@
             <div class="testimonial-quote text-left">
               <p class="text-muted">
                 We use the card handling service
-                <a href="https://stripe.com" target="_blank">Stripe</a> to process your customer's payment (they're the ones charging the 1.5% :). Once payment is successful, it goes straight into your bank account, minus any fees payable.
+                <a href="https://stripe.com" target="_blank">Stripe</a> to process your customer's payment (they're the ones charging the 1.4%). Once payment is successful, it goes straight into your bank account, minus any fees payable.
                 <br/>
                 <br/> 
                 Saving you the hassle of dealing with bank transfers and chasing payments - yet again! &#x1F44F


### PR DESCRIPTION
Previous work amended the pricing card FAQ which told visitors that Stripe charge 1.4% but on the other card it was 1.5%.

This fixes that contradiction.

Before:
![image](https://user-images.githubusercontent.com/1453680/54472894-3b928480-47c8-11e9-99fa-dda8effb249c.png)

After:

![image](https://user-images.githubusercontent.com/1453680/54472899-4fd68180-47c8-11e9-97fd-e445be39860e.png)

