### PR TITLE
Use new video in iFrame to prevent users having to click play 2x.

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,9 +171,9 @@
   </section>
   <section class="video-1 no-padding" id="video">
     <div class="videoWrapper">
-      <img class="placeholder" src="img/design-video-snapshot.png" data-video="https://player.vimeo.com/video/310397568?byline=0&portrait=0&autoplay=1">
-      <!-- <iframe src="https://player.vimeo.com/video/259486606?byline=0&portrait=0" width="640" height="400" frameborder="0" webkitallowfullscreen
-        mozallowfullscreen allowfullscreen></iframe> -->
+      <!-- <img class="placeholder" src="img/design-video-snapshot.png" data-video="https://player.vimeo.com/video/310397568?byline=0&portrait=0&autoplay=1"> -->
+      <iframe src="https://player.vimeo.com/video/310397568?byline=0&portrait=0" width="640" height="400" frameborder="0" webkitallowfullscreen
+        mozallowfullscreen allowfullscreen></iframe>
     </div>
   </section>
   <section class="functionality bg-gray" id="features">


### PR DESCRIPTION
Use new video in iFrame to prevent users having to click play 2x.

Chrome has prevented autoplay. Having the image solution previously
implemented meant users were having to click twice to watch the
video.