### PR TITLE
Add Drift chat widget to site.

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,34 @@
   <meta name="twitter:card" content="Simplify Your Group Bookings">
   <meta property="og:site_name" content="mybookingsherpa.com">
   <meta name="twitter:image:alt" content="www.mybookingsherpa.com">
+  <!-- Start of Async Drift Code -->
+  <script>
+  "use strict";
+
+  !function() {
+    var t = window.driftt = window.drift = window.driftt || [];
+    if (!t.init) {
+      if (t.invoked) return void (window.console && console.error && console.error("Drift snippet included twice."));
+      t.invoked = !0, t.methods = [ "identify", "config", "track", "reset", "debug", "show", "ping", "page", "hide", "off", "on" ], 
+      t.factory = function(e) {
+        return function() {
+          var n = Array.prototype.slice.call(arguments);
+          return n.unshift(e), t.push(n), t;
+        };
+      }, t.methods.forEach(function(e) {
+        t[e] = t.factory(e);
+      }), t.load = function(t) {
+        var e = 3e5, n = Math.ceil(new Date() / e) * e, o = document.createElement("script");
+        o.type = "text/javascript", o.async = !0, o.crossorigin = "anonymous", o.src = "https://js.driftt.com/include/" + n + "/" + t + ".js";
+        var i = document.getElementsByTagName("script")[0];
+        i.parentNode.insertBefore(o, i);
+      };
+    }
+  }();
+  drift.SNIPPET_VERSION = '0.3.1';
+  drift.load('n4zvt2kb6kk6');
+  </script>
+  <!-- End of Async Drift Code -->
 </head>
 
 <body id="page-top" data-scroll-animation="true">


### PR DESCRIPTION
##### What's this pull request do?
Adds the Drift chat widget to site.

##### Background...
Asking people to enter their emails is a big ask.
Asking people to chat in a Drift-powered widget on the site is less so.

##### What's the goal?
To start talking to visitors interested in our service. So we can get them onboard, learn from them and help them.

##### Screenshots
![image](https://user-images.githubusercontent.com/1453680/56075474-3c183e00-5dbb-11e9-8402-a5aab8ffd933.png)


