### PR TITLE
Remove wording in personal touch 

### DIFF
--- a/index.html
+++ b/index.html
@@ -412,7 +412,7 @@
             <h2>Would I loose the personal touch?</h2>
             <div class="testimonial-quote text-left">
               <p class="text-muted">
-                No one wants to talk to robots. We let you add your own personalised email responses that are sent to your guests when they book.
+                No one wants to talk to robots. 
                 <br/>
                 <br/> If they have a special request (other than: "Why is this booking process so damn easy...?") then there's always your own email address on the page for getting deep and personal.
                 <br/>


### PR DESCRIPTION
Remove wording in the personal touch card that describes a feature we do not have in the app.

<img width="674" alt="Screenshot 2019-12-09 at 11 15 40" src="https://user-images.githubusercontent.com/2472713/70431646-64089000-1a75-11ea-9f12-9332338c2bc4.png">
