### PR TITLE
Replace contact with simple "Start free trial" CTA - WIP

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1784,10 +1784,10 @@ section.faqs .faq p {
     width: 100%;
   }
 }
-.contact-with-map .contact-form {
+.contact-with-map .start-free-trial-form {
   margin-top: 15px;
 }
-.contact-with-map .contact-form .textarea {
+.contact-with-map .start-free-trial-form .textarea {
   min-height: 220px;
   resize: none;
 }
@@ -1824,18 +1824,18 @@ section.faqs .faq p {
   width: 100%;
   height: 100%;
 }
-.contact-default .contact-form {
+.start-free-trial-default .start-free-trial-form {
   margin-top: 15px;
 }
-.contact-default .contact-form .textarea {
+.start-free-trial-default .start-free-trial-form .textarea {
   min-height: 220px;
   resize: none;
 }
-.contact-default .info-meta h3 {
+.start-free-trial-default .info-meta h3 {
   font-family: 'Nunito', sans-serif;
   color: #424753;
 }
-.contact-default .form-control {
+.start-free-trial-default .form-control {
   box-shadow: none;
   border-color: #eee;
   height: 49px;
@@ -1848,28 +1848,28 @@ section.faqs .faq p {
   justify-content: center;
   align-items: center;
 }
-.contact-default .form-control:focus {
+.start-free-trial-default .form-control:focus {
   box-shadow: none;
   border-color: #38b4ef;
 }
-.contact-default .form-control-feedback {
+.start-free-trial-default .form-control-feedback {
   line-height: 50px;
 }
-.contact-default .form-control-feedback {
+.start-free-trial-default .form-control-feedback {
   line-height: 50px;
   top: 0px;
 }
-.contact-default .map-column {
+.start-free-trial-default .map-column {
   padding: 0;
   position: relative;
 }
 @media (max-width: 768px) {
-  .contact-default .map-column {
+  .start-free-trial-default .map-column {
     height: 250px;
     width: 100%;
   }
 }
-.contact-default .map-column .map-container {
+.start-free-trial-default .map-column .map-container {
   position: absolute;
   top: 0;
   left: 0;

--- a/css/style.css
+++ b/css/style.css
@@ -1838,7 +1838,8 @@ section.faqs .faq p {
 .start-free-trial-default .form-control {
   box-shadow: none;
   border-color: #eee;
-  height: 49px;
+  height: 44px;
+  font-size: 18px;
 }
 .captcha-position {
   padding-top: 20px;

--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
             <a class="page-scroll" href="#questions">FAQs</a>
           </li>
           <li>
-            <a class="page-scroll" href="#contact">Contact</a>
+            <a class="page-scroll" href="https://app.mybookingsherpa.com/guides/sign_up">Start Free Trial</a>
           </li>
         </ul>
       </div>
@@ -127,7 +127,17 @@
             Not the Admin
           </h1>
           <h2>Take Instant Card Payments for All Your Bookings</h2>
-          <a href="#video" class="btn btn-rect btn-rect--dark btn-xl page-scroll wow fadeInUp" data-wow-delay="0.3s">Show Me the Video</a>
+          <!-- <a href="#video" class="btn btn-rect btn-rect--dark btn-xl page-scroll wow fadeInUp" data-wow-delay="0.3s">Show Me the Video</a> -->
+          <div class="row">
+            <form role="form" id="contact-form" class="start-free-trial" method="GET" action="https://app.mybookingsherpa.com/guides/sign_up">
+                <div class="col-sm-5 col-sm-offset-2">
+                  <input type="email" class="form-control" style="padding-bottom: 27px; padding-top: 27px;" name="email" id="email" placeholder="Your email">
+                </div>
+                <div class="col-sm-2">
+                  <button class="btn btn-rect btn-xl btn-rect--dark" id="submit" type="submit">Start Free Trial</button>
+                </div>
+            </form>
+          </div>
         </div>
       </div>
       <div class="col-sm-12 wow fadeInUp" data-wow-delay="0.6s">
@@ -468,28 +478,19 @@
       <!-- end Col -->
     </div>
   </section>
-  <section class="contact-default splash splash--primary" id="contact">
+  <section class="start-free-trial-default splash splash--primary" id="start-free-trial">
     <h1 class="heading-text">
-      Interested? We want to talk to you.
+      Start your free trial now.
     </h1>
-    <form role="form" id="contact-form" class="contact-form" method="GET" action="https://place.us17.list-manage.com/subscribe/post-json?u=9f9d7b0506c15fe539fba8b45&amp;id=8d0edf259f&c=?">
+    <form role="form" id="contact-form" class="start-free-trial" method="GET" action="https://app.mybookingsherpa.com/guides/sign_up">
       <div class="row">
         <div class="col-md-4 col-md-offset-4">
           <div class="form-group">
-            <input type="email" class="form-control" name="EMAIL" autocomplete="off" id="Email" placeholder="Enter your email and we'll get straight back to you">
+            <input type="email" class="form-control" name="email" id="email" placeholder="Your email">
           </div>
         </div>
       </div>
-      <button class="btn btn-rect btn-xl btn-rect--dark" id="submit" type="submit">Email Us</button>
-      <div id="responseMessage"></div>
-      <div style="left: -9999px; position: absolute" aria-label="Please leave the following three fields empty">
-        <label for="b_name">Name: </label>
-        <input type="text" name="b_name" tabindex="-1" value="" placeholder="Freddie" id="b_name">
-        <label for="b_email">Email: </label>
-        <input type="email" name="b_email" tabindex="-1" value="" placeholder="youremail@gmail.com" id="b_email">
-        <label for="b_comment">Comment: </label>
-        <textarea name="b_comment" tabindex="-1" placeholder="Please comment" id="b_comment"></textarea>
-      </div>
+      <button class="btn btn-rect btn-xl btn-rect--dark" id="submit" type="submit">Start free trial</button>
     </form>
   </section>
   <footer class="footer footer--light">
@@ -515,40 +516,10 @@
   <script src="js/index.min.js"></script>
 
   <script>
-    document.getElementById('contact-form').addEventListener('submit', (e) => {
-      e.preventDefault();
-      postEmailAddress($('#contact-form'));
-    });
-
     $('.placeholder').click(function () {
       video = '<iframe src="' + $(this).attr('data-video') + '" width="640" height="400" frameborder="0"></iframe>';
       $(this).replaceWith(video);
     });
-
-
-    function postEmailAddress($form) {
-      $.ajax({
-        type: $form.attr('method'),
-        url: $form.attr('action'),
-        data: $form.serialize(),
-        cache: false,
-        dataType: 'json',
-        contentType: "application/json; charset=utf-8",
-        error: function (err) { alert("Could not connect to the registration server. Please try again later."); },
-        success: function (data) {
-          if (data.result != "success") {
-            // Something went wrong, do something to notify the user.
-            console.log('failure ' + data.msg);
-            document.getElementById('Email').value = '';
-          } else {
-            console.log('Success');
-            document.getElementById('Email').value = '';
-            document.getElementById('responseMessage').innerHTML = "Thank you. We will get back to you shortly."
-          }
-        }
-      });
-    };
-
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -129,12 +129,12 @@
           <h2>Take Instant Card Payments for All Your Bookings</h2>
           <!-- <a href="#video" class="btn btn-rect btn-rect--dark btn-xl page-scroll wow fadeInUp" data-wow-delay="0.3s">Show Me the Video</a> -->
           <div class="row">
-            <form role="form" id="contact-form" class="start-free-trial" method="GET" action="https://app.mybookingsherpa.com/guides/sign_up">
-                <div class="col-sm-5 col-sm-offset-2">
-                  <input type="email" class="form-control" style="padding-bottom: 27px; padding-top: 27px;" name="email" id="email" placeholder="Your email">
+            <form role="form" id="contact-form" class="start-free-trial-default" method="GET" action="https://app.mybookingsherpa.com/guides/sign_up">
+                <div class="col-sm-5 col-sm-offset-2 form-group">
+                  <input type="email" class="form-control" name="email" id="email" placeholder="Your email">
                 </div>
-                <div class="col-sm-2">
-                  <button class="btn btn-rect btn-xl btn-rect--dark" id="submit" type="submit">Start Free Trial</button>
+                <div class="col-sm-2 form-group">
+                  <button class="btn btn-rect btn-lg btn-rect--dark" id="submit" type="submit">Start Free Trial</button>
                 </div>
             </form>
           </div>


### PR DESCRIPTION
Replace contact with simple "Start free trial" CTA

Part of the work to prepare for Jan 2020 Launch.

We will be sending the guides a link to the marketing page.

We should make it easier to get them to start the free trial.


![image](https://user-images.githubusercontent.com/1453680/71559188-3d75bd80-2a53-11ea-9b74-a2798f08c580.png)

Could do with a bit of work for the mobile view:
![image](https://user-images.githubusercontent.com/1453680/71559202-6302c700-2a53-11ea-844a-2ecbd866f7c8.png)

![image](https://user-images.githubusercontent.com/1453680/71559277-1b306f80-2a54-11ea-9455-aad476ddc5c7.png)


Will need to change code in the https://app.mybookingsherpa.com/guides/sign_up view - to inject the email param from here into the form....