### PR TITLE
fix line height

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,22 +336,6 @@
       <div class="text-center">
         <div class="row">
           <div class="col-md-6 wow fadeInUp" data-wow-delay="0.3s">
-            <h2>How much does it cost?</h2>
-            <div class="testimonial-quote text-left text-muted">
-              <p class="text-muted">
-                <h2 class="text-center text-muted">1%</h2>
-                <br/>
-                ...per booking, with a minimum cost of €2/£2.
-                <br/>
-                <br/>
-                We also process <a href="https://stripe.com/gb/pricing" target="_blank">the card handler fee</a> on your behalf (that you have to pay anyway when you take card payments) which is 1.4%.
-                <br/>
-                <br/>
-                For this, we allow you to take instant card payments, deal with all your payment processing, handle each booking, send new guest emails, handle deposit payments, automatically charge the outstanding payment at the correct date, chase late payments, organise and secure your customer data, update guest numbers, etc... so much... for so little.                
-              </p>
-            </div>
-          </div>
-          <div class="col-md-6 wow fadeInUp" data-wow-delay="0.6s">
             <h2>How does it work?</h2>
             <div class="testimonial-quote text-left">
               <p class="text-muted">
@@ -371,6 +355,21 @@
               </p>
             </div>
           </div>
+          <div class="col-md-6 wow fadeInUp" data-wow-delay="0.6s">
+            <h2>How much does it cost?</h2>
+            <div class="testimonial-quote text-left text-muted">
+              <h2 class="text-center text-muted">1%</h2>
+              <p class="text-muted">
+                <br/>...per booking, with a minimum cost of €2/£2.
+                <br/>
+                <br/>
+                We also process <a href="https://stripe.com/gb/pricing" target="_blank">the card handler fee</a> on your behalf (that you have to pay anyway when you take card payments) which is 1.4%.
+                <br/>
+                <br/>
+                For this, we allow you to take instant card payments, deal with all your payment processing, handle each booking, send new guest emails, handle deposit payments, automatically charge the outstanding payment at the correct date, chase late payments, organise and secure your customer data, update guest numbers, etc... so much... for so little.                
+              </p>
+            </div>
+          </div>
           <div class="col-md-6 wow fadeInUp" data-wow-delay="0.3s">
             <h2>Where does the money go?</h2>
             <div class="testimonial-quote text-left">
@@ -386,9 +385,8 @@
           <div class="col-md-6 wow fadeInUp" data-wow-delay="0.6s">
             <h2>Is there a minimum contract? / Am I tied into a subscription?</h2>
             <div class="testimonial-quote text-left text-muted">
-              <p class="text-muted">
-                <h3 class="text-center text-muted">No.</h3>
-                <!-- <br/> -->
+              <h2 class="text-center text-muted">No.</h2>
+              <p class="text-muted"> 
                 <br/> We're nice guys and we don't want to tie you up if you don't want to be with us.
                 <br/>
                 <br/>


### PR DESCRIPTION
Work to fix the FAQ line height in some of the boxes.

The heading tags were inside the paragraph tags, causing the styles to be lost.

I have also switched the order of How does it work? <-> How much does it cost?
as the style fixes caused a lot of white space between boxes. The information still flows well.

<img width="1182" alt="Screenshot 2020-03-09 at 15 56 47" src="https://user-images.githubusercontent.com/2472713/76232967-610d6f00-621f-11ea-9a25-54bd369ab976.png">
