### PR TITLE
Update minimum fee from 2 to 4 €/£.

### DIFF
--- a/index.html
+++ b/index.html
@@ -372,7 +372,7 @@
             <div class="testimonial-quote text-left text-muted">
               <h2 class="text-center text-muted">1%</h2>
               <p class="text-muted">
-                <br/>...per booking, with a minimum cost of €2/£2.
+                <br/>...per booking, with a minimum cost of €4/£4.
                 <br/>
                 <br/>
                 We also process <a href="https://stripe.com/gb/pricing" target="_blank">the card handler fee</a> on your behalf (that you have to pay anyway when you take card payments) which is 1.4%.


### PR DESCRIPTION
After a basic economic unit analysis we would of been making about 2p
profit in certain circumstances, ie: when a guide with multiple low cost
trips every month through the year.

This should fix that or just weed out those who are not willing to pay
£/€4. So we can actually, hopefully make some money.

Will need to actually implement the new minimum in the app itself too.

![image](https://user-images.githubusercontent.com/1453680/87925874-d19f8480-ca78-11ea-90c9-6f0fb93ae436.png)
